### PR TITLE
Add Encoder concept

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
  * `SourceSample` class can serve as a general intermediate object for different kind of source types
  * Configuration for sources.pcSamples 
  * `Sources` singletone object to funnel different type of sources
+ * Encoders concept, to make different type of encoding for sink for reports possible
+ * `AvroEncoder`, `AvroEncoderBuilder`, `EncoderBuilder` for encoding
+ 
 
 ### Deprecated
  * Websocket URL address /{serviceUUID}/{mediaUnitId}/v20200114/json

--- a/docs/index.md
+++ b/docs/index.md
@@ -447,6 +447,7 @@ A connector object can be described as follows:
 ```yaml
 name: "MyConnectorName"  # required
 transformations: []      # optional
+encoder: {}              # optional
 buffer: {}               # optional
 sink: {}                 # required
 ```
@@ -454,6 +455,10 @@ sink: {}                 # required
 
 **Transformations**: A connector may have transformations, such as 
 Filter, or Obfuscator. Transformations are optional.
+
+**Encoder**: Specifies the encoding from an inner Report format 
+to the sink accepted byte array format with optional meta information.
+The default encoder is AvroEncoder.
 
 **Buffer**: A buffer takes place between the observer
 inner pipeline forwarded report and the sink. 
@@ -472,6 +477,10 @@ connectors:
           serviceName:
             including:
               - "MyService"
+    encoder:
+      type: AvroEncoder
+      config:
+        addMetaKey: True
     buffer:
       maxItems: 100
       maxWaitingTimeInS: 30

--- a/src/main/java/org/observertc/webrtc/observer/connectors/ConnectorBuilder.java
+++ b/src/main/java/org/observertc/webrtc/observer/connectors/ConnectorBuilder.java
@@ -6,6 +6,8 @@ import io.reactivex.rxjava3.disposables.Disposable;
 import io.reactivex.rxjava3.functions.Function;
 import org.observertc.webrtc.observer.common.ObjectToString;
 import org.observertc.webrtc.observer.configbuilders.AbstractBuilder;
+import org.observertc.webrtc.observer.connectors.encoders.Encoder;
+import org.observertc.webrtc.observer.connectors.encoders.EncoderBuilder;
 import org.observertc.webrtc.observer.connectors.sinks.Sink;
 import org.observertc.webrtc.observer.connectors.sinks.SinkBuilder;
 import org.observertc.webrtc.observer.connectors.transformations.Transformation;
@@ -55,6 +57,15 @@ public class ConnectorBuilder extends AbstractBuilder implements Function<Map<St
             result.withTransformation(transformation);
         }
 
+        EncoderBuilder encoderBuilder = new EncoderBuilder();
+        encoderBuilder.withConfiguration(config.encoder);
+        Optional<Encoder> encoder = encoderBuilder.build();
+        if (!encoder.isPresent()) {
+            logger.warn("Cannot make a pipeline without an encoder");
+            return Optional.empty();
+        }
+        result.withEncoder(encoder.get());
+
         result.withBuffer(config.buffer);
 
         SinkBuilder sinkBuilder = new SinkBuilder();
@@ -77,6 +88,8 @@ public class ConnectorBuilder extends AbstractBuilder implements Function<Map<St
         public List<Map<String, Object>> transformations = new ArrayList<>();
 
         public BufferConfig buffer = new BufferConfig();
+
+        public Map<String, Object> encoder = new HashMap<>();
 
         @NotNull
         public Map<String, Object> sink;

--- a/src/main/java/org/observertc/webrtc/observer/connectors/EncodedRecord.java
+++ b/src/main/java/org/observertc/webrtc/observer/connectors/EncodedRecord.java
@@ -1,0 +1,54 @@
+package org.observertc.webrtc.observer.connectors;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+public class EncodedRecord {
+    private static final String KEY_FIELD_NAME = "key";
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    private byte[] message;
+    private Map<String, Object> meta = new HashMap<>();
+
+    public EncodedRecord(byte[] message) {
+        this.message = message;
+    }
+
+    private EncodedRecord() {
+
+    }
+
+    public byte[] getMessage() {
+        return this.message;
+    }
+
+    public UUID getKey() {
+        return (UUID) this.meta.get(KEY_FIELD_NAME);
+    }
+
+    public static class Builder {
+        private final EncodedRecord result = new EncodedRecord();
+
+        public<T> Builder withMeta(String key, T value) {
+            this.result.meta.put(key, value);
+            return this;
+        }
+
+        public Builder withKey(UUID value) {
+            this.result.meta.put(KEY_FIELD_NAME, value);
+            return this;
+        }
+
+        public<T> Builder withMessage(byte[] message) {
+            this.result.message = message;
+            return this;
+        }
+
+        public EncodedRecord build() {
+            return this.result;
+        }
+    }
+}

--- a/src/main/java/org/observertc/webrtc/observer/connectors/encoders/AvroEncoder.java
+++ b/src/main/java/org/observertc/webrtc/observer/connectors/encoders/AvroEncoder.java
@@ -1,0 +1,39 @@
+package org.observertc.webrtc.observer.connectors.encoders;
+
+import org.observertc.webrtc.observer.connectors.EncodedRecord;
+import org.observertc.webrtc.schemas.reports.Report;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.nio.ByteBuffer;
+import java.util.function.BiConsumer;
+
+public class AvroEncoder implements Encoder {
+    private static final Logger logger = LoggerFactory.getLogger(AvroEncoder.class);
+
+    private BiConsumer<EncodedRecord.Builder, Report> metaBuilder = (e, r) -> {};
+
+    @Override
+    public EncodedRecord apply(Report report) throws Throwable {
+        ByteBuffer message;
+        try {
+            message = Report.getEncoder().encode(report);
+        } catch (Throwable t) {
+            logger.warn("Cannot encode report {}", report, t);
+            return null;
+        }
+        if (!message.hasArray()) {
+            logger.warn("Failed to encode report {}", report);
+            return null;
+        }
+        EncodedRecord.Builder recordBuilder = EncodedRecord.builder();
+        recordBuilder.withMessage(message.array());
+        this.metaBuilder.accept(recordBuilder, report);
+        return recordBuilder.build();
+    }
+
+    AvroEncoder withMetaBuilder(BiConsumer<EncodedRecord.Builder, Report> metaBuilder) {
+        this.metaBuilder = this.metaBuilder.andThen(metaBuilder);
+        return this;
+    }
+}

--- a/src/main/java/org/observertc/webrtc/observer/connectors/encoders/AvroEncoderBuilder.java
+++ b/src/main/java/org/observertc/webrtc/observer/connectors/encoders/AvroEncoderBuilder.java
@@ -1,0 +1,38 @@
+package org.observertc.webrtc.observer.connectors.encoders;
+
+import org.observertc.webrtc.observer.configbuilders.AbstractBuilder;
+import org.observertc.webrtc.observer.configbuilders.Builder;
+import org.observertc.webrtc.observer.connectors.EncodedRecord;
+import org.observertc.webrtc.schemas.reports.Report;
+
+import java.util.UUID;
+import java.util.function.BiConsumer;
+
+public class AvroEncoderBuilder extends AbstractBuilder implements Builder<Encoder> {
+
+    @Override
+    public Encoder build() {
+        AvroEncoder result = new AvroEncoder();
+        AvroEncoderConfig config = this.convertAndValidate(AvroEncoderConfig.class);
+        if (config.addMetaKey) {
+            BiConsumer<EncodedRecord.Builder, Report> metaKeyBuilder = this.makeMetaKeyMaker();
+            result.withMetaBuilder(metaKeyBuilder);
+        }
+        return result;
+    }
+
+    BiConsumer<EncodedRecord.Builder, Report> makeMetaKeyMaker() {
+        final ReportKeyMaker keyMaker = new ReportKeyMaker();
+        return new BiConsumer<EncodedRecord.Builder, Report>() {
+            @Override
+            public void accept(EncodedRecord.Builder recordBuilder, Report report) {
+                UUID key = keyMaker.apply(report);
+                recordBuilder.withKey(key);
+            }
+        };
+    }
+
+    public static class AvroEncoderConfig {
+        public boolean addMetaKey = true;
+    }
+}

--- a/src/main/java/org/observertc/webrtc/observer/connectors/encoders/Encoder.java
+++ b/src/main/java/org/observertc/webrtc/observer/connectors/encoders/Encoder.java
@@ -1,0 +1,9 @@
+package org.observertc.webrtc.observer.connectors.encoders;
+
+import io.reactivex.rxjava3.functions.Function;
+import org.observertc.webrtc.observer.connectors.EncodedRecord;
+import org.observertc.webrtc.schemas.reports.Report;
+
+public interface Encoder extends Function<Report, EncodedRecord> {
+
+}

--- a/src/main/java/org/observertc/webrtc/observer/connectors/encoders/EncoderBuilder.java
+++ b/src/main/java/org/observertc/webrtc/observer/connectors/encoders/EncoderBuilder.java
@@ -1,0 +1,42 @@
+package org.observertc.webrtc.observer.connectors.encoders;
+
+import io.micronaut.context.annotation.Prototype;
+import org.observertc.webrtc.observer.configbuilders.AbstractBuilder;
+import org.observertc.webrtc.observer.configbuilders.Builder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * To make the package scannable, we need to add this annotation
+ */
+@Prototype
+public class EncoderBuilder extends AbstractBuilder {
+
+    private static final Logger logger = LoggerFactory.getLogger(EncoderBuilder.class);
+
+    public EncoderBuilder() {
+
+    }
+
+    public Optional<Encoder> build() {
+        EncoderConfig config = this.convertAndValidate(EncoderConfig.class);
+
+        String builderClassName = AbstractBuilder.getBuilderClassName(config.type);
+        Optional<Builder> builderHolder = this.tryInvoke(builderClassName);
+        if (!builderHolder.isPresent()) {
+            logger.warn("Encoder builder for class {} has not been found", config.type);
+            return Optional.empty();
+        }
+        Builder<Encoder> builder = builderHolder.get();
+        builder.withConfiguration(config.config);
+        Encoder result = builder.build();
+        if (Objects.isNull(result)) {
+            return Optional.empty();
+        }
+        return Optional.of(result);
+    }
+
+}

--- a/src/main/java/org/observertc/webrtc/observer/connectors/encoders/EncoderConfig.java
+++ b/src/main/java/org/observertc/webrtc/observer/connectors/encoders/EncoderConfig.java
@@ -1,0 +1,11 @@
+package org.observertc.webrtc.observer.connectors.encoders;
+
+import java.util.Map;
+
+public class EncoderConfig {
+
+    public String type = AvroEncoder.class.getSimpleName();
+
+    public Map<String, Object> config;
+
+}

--- a/src/main/java/org/observertc/webrtc/observer/connectors/encoders/ReportKeyMaker.java
+++ b/src/main/java/org/observertc/webrtc/observer/connectors/encoders/ReportKeyMaker.java
@@ -1,0 +1,94 @@
+package org.observertc.webrtc.observer.connectors.encoders;
+
+import org.observertc.webrtc.observer.common.ReportVisitor;
+import org.observertc.webrtc.schemas.reports.*;
+
+import java.util.UUID;
+
+public class ReportKeyMaker implements ReportVisitor<UUID> {
+
+    @Override
+    public UUID visitTrackReport(Report report, Track payload) {
+        return UUID.fromString(payload.getPeerConnectionUUID());
+    }
+
+    @Override
+    public UUID visitFinishedCallReport(Report report, FinishedCall payload) {
+        return UUID.fromString(report.getServiceUUID());
+    }
+
+    @Override
+    public UUID visitInitiatedCallReport(Report report, InitiatedCall payload) {
+        return UUID.fromString(report.getServiceUUID());
+    }
+
+    @Override
+    public UUID visitJoinedPeerConnectionReport(Report report, JoinedPeerConnection payload) {
+        return UUID.fromString(payload.getPeerConnectionUUID());
+    }
+
+    @Override
+    public UUID visitDetachedPeerConnectionReport(Report report, DetachedPeerConnection payload) {
+        return UUID.fromString(payload.getPeerConnectionUUID());
+    }
+
+    @Override
+    public UUID visitInboundRTPReport(Report report, InboundRTP payload) {
+        return UUID.fromString(payload.getPeerConnectionUUID());
+    }
+
+    @Override
+    public UUID visitOutboundRTPReport(Report report, OutboundRTP payload) {
+        return UUID.fromString(payload.getPeerConnectionUUID());
+    }
+
+    @Override
+    public UUID visitRemoteInboundRTPReport(Report report, RemoteInboundRTP payload) {
+        return UUID.fromString(payload.getPeerConnectionUUID());
+    }
+
+    @Override
+    public UUID visitMediaSourceReport(Report report, MediaSource payload) {
+        return UUID.fromString(payload.getPeerConnectionUUID());
+    }
+
+    @Override
+    public UUID visitObserverReport(Report report, ObserverEventReport payload) {
+        return UUID.fromString(report.getServiceUUID());
+    }
+
+    @Override
+    public UUID visitUserMediaErrorReport(Report report, UserMediaError payload) {
+        return UUID.fromString(report.getServiceUUID());
+    }
+
+    @Override
+    public UUID visitICECandidatePairReport(Report report, ICECandidatePair payload) {
+        return UUID.fromString(payload.getPeerConnectionUUID());
+    }
+
+    @Override
+    public UUID visitICELocalCandidateReport(Report report, ICELocalCandidate payload) {
+        return UUID.fromString(payload.getPeerConnectionUUID());
+    }
+
+    @Override
+    public UUID visitICERemoteCandidateReport(Report report, ICERemoteCandidate payload) {
+        return UUID.fromString(payload.getPeerConnectionUUID());
+    }
+
+    @Override
+    public UUID visitUnrecognizedReport(Report report) {
+        return UUID.fromString(report.getServiceUUID());
+    }
+
+    @Override
+    public UUID visitExtensionReport(Report report, ExtensionReport payload) {
+        return UUID.fromString(report.getServiceUUID());
+    }
+
+    @Override
+    public UUID visitUnknownType(Report report) {
+        return UUID.fromString(report.getServiceUUID());
+    }
+}

--- a/src/main/java/org/observertc/webrtc/observer/connectors/sinks/Sink.java
+++ b/src/main/java/org/observertc/webrtc/observer/connectors/sinks/Sink.java
@@ -3,14 +3,14 @@ package org.observertc.webrtc.observer.connectors.sinks;
 import io.reactivex.rxjava3.annotations.NonNull;
 import io.reactivex.rxjava3.core.Observer;
 import io.reactivex.rxjava3.disposables.Disposable;
-import org.observertc.webrtc.schemas.reports.Report;
+import org.observertc.webrtc.observer.connectors.EncodedRecord;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.List;
 import java.util.Objects;
 
-public abstract class Sink implements Observer<List<Report>> {
+public abstract class Sink implements Observer<List<EncodedRecord>> {
     private static final Logger DEFAULT_LOGGER = LoggerFactory.getLogger(Sink.class);
     private Disposable upstream;
     protected Logger logger = DEFAULT_LOGGER;

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -114,6 +114,10 @@ observer:
 #        - "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
   connectors:
     - name: "ReportSinkLogger"
+      encoder:
+        type: AvroEncoder
+        config:
+          addMetaKey: True
       buffer:
         maxItems: 100
         maxWaitingTimeInS: 10


### PR DESCRIPTION
 * Alter Sink to accept `EncodedRecord`s, which is a byte and meta dict. combination
 * Alter KafkaSink to match with Sink
 * Alter LoggerSink to match with Sink
 * Alter Connector, and ConnectorBuilder to use encoders before the buffer, and buffer collects EncodedRecords
 * Add AvroEncoder
 * Add AvroEncoderBuilder
 * Add EncoderBuilder, similar to TransformationBuilder accept maps and invokes the appropriate builder for encoder.
 * Decompose ReportKeyMaker from KafkaSink, and keymaking is part of the encoding process as a metadata