### PR TITLE
 Avoid processing any records for a report that have no firehose sink

### DIFF
--- a/src/main/java/org/observertc/observer/sinks/CsvFormatEncoder.java
+++ b/src/main/java/org/observertc/observer/sinks/CsvFormatEncoder.java
@@ -67,6 +67,11 @@ public class CsvFormatEncoder<K, V> implements FormatEncoder<K, V> {
             for (var it = reportsByTypes.entrySet().iterator(); it.hasNext(); ) {
                 var entry = it.next();
                 var type = entry.getKey();
+                K mappedType = typeMapper.apply(type);
+                if (mappedType == null) {
+                    continue;
+                }
+
                 var groupedReports = entry.getValue();
                 for (var jt = groupedReports.iterator(); jt.hasNext(); ) {
                     var report = jt.next();
@@ -77,12 +82,8 @@ public class CsvFormatEncoder<K, V> implements FormatEncoder<K, V> {
                     }
                     csvPrinter.flush();
                     var lines = stringBuilder.toString();
-                    K mappedType = typeMapper.apply(report.type);
                     V myRecord = this.formatMapper.apply(lines);
 
-                    if (mappedType == null) {
-                        continue;
-                    }
                     var mappedRecords = records.get(mappedType);
                     if (mappedRecords == null) {
                         mappedRecords = new LinkedList<>();


### PR DESCRIPTION
The current logic doesn't create a new CSVPrinter and StringBuilder for each record type and this interacts badly with the logic that will try to ignore record types if there is no kinesis stream to send the records to.

This is now changed to make sure that csvPrinter and StringBuilder are initialised before starting to process a record type. Secondly, the ignoring logic is slightly simplified so that it will not process the first record for a given type.